### PR TITLE
fix: capture response from raw_call

### DIFF
--- a/contracts/GateSeal.vy
+++ b/contracts/GateSeal.vy
@@ -162,7 +162,8 @@ def seal(_sealables: DynArray[address, MAX_SEALABLES]):
         response: Bytes[32] = b""
 
         # using `raw_call` to catch external revert and continue execution
-        # capturing `response` to keep the compiler from acting out,
+        # capturing `response` to keep the compiler from acting out but will not be checking it
+        # as different sealables may return different values if anything at all
         # for details, see https://docs.vyperlang.org/en/stable/built-in-functions.html#raw_call
         success, response = raw_call(
             sealable,

--- a/contracts/GateSeal.vy
+++ b/contracts/GateSeal.vy
@@ -159,11 +159,15 @@ def seal(_sealables: DynArray[address, MAX_SEALABLES]):
         assert sealable in self.sealables, "sealables: includes a non-sealable"
 
         success: bool = False
+        response: Bytes[32] = b""
 
         # using `raw_call` to catch external revert and continue execution
-        success = raw_call(
+        # capturing `response` to keep the compiler from what acting out,
+        # for details, see https://docs.vyperlang.org/en/stable/built-in-functions.html#raw_call
+        success, response = raw_call(
             sealable,
             _abi_encode(SEAL_DURATION_SECONDS, method_id=method_id("pauseFor(uint256)")),
+            max_outsize=32,
             revert_on_failure=False
         )
         

--- a/contracts/GateSeal.vy
+++ b/contracts/GateSeal.vy
@@ -162,7 +162,7 @@ def seal(_sealables: DynArray[address, MAX_SEALABLES]):
         response: Bytes[32] = b""
 
         # using `raw_call` to catch external revert and continue execution
-        # capturing `response` to keep the compiler from what acting out,
+        # capturing `response` to keep the compiler from acting out,
         # for details, see https://docs.vyperlang.org/en/stable/built-in-functions.html#raw_call
         success, response = raw_call(
             sealable,

--- a/contracts/test_helpers/SealableMock.vy
+++ b/contracts/test_helpers/SealableMock.vy
@@ -17,6 +17,13 @@ def isPaused() -> bool:
 
 
 @external
+def __force_pause_for(_duration: uint256):
+    # pause ignoring any checks
+    # required to simulate cases where Sealable is already paused but the seal() reverts
+    self.resumed_timestamp = block.timestamp + _duration
+
+
+@external
 def pauseFor(_duration: uint256):
     assert not self.reverts, "simulating revert"
     if not self.unpausable and not self._is_paused():

--- a/tests/test_gate_seal.py
+++ b/tests/test_gate_seal.py
@@ -430,7 +430,7 @@ def test_cannot_seal_twice_in_one_tx(gate_seal, sealables, sealing_committee):
         gate_seal.seal(sealables, sender=sealing_committee)
 
 
-def test_raw_call_response_should_be_false_when_sealable_reverts_on_pause(project, deployer, generate_sealables, sealing_committee, seal_duration_seconds, expiry_timestamp):
+def test_raw_call_success_should_be_false_when_sealable_reverts_on_pause(project, deployer, generate_sealables, sealing_committee, seal_duration_seconds, expiry_timestamp):
     """
         `raw_call` without `max_outsize` and with `revert_on_failure=True` for some reason returns the boolean value of storage[0] :^)
 

--- a/tests/test_gate_seal.py
+++ b/tests/test_gate_seal.py
@@ -432,13 +432,13 @@ def test_cannot_seal_twice_in_one_tx(gate_seal, sealables, sealing_committee):
 
 def test_raw_call_success_should_be_false_when_sealable_reverts_on_pause(project, deployer, generate_sealables, sealing_committee, seal_duration_seconds, expiry_timestamp):
     """
-        `raw_call` without `max_outsize` and with `revert_on_failure=True` for some reason returns the boolean value of storage[0] :^)
+        `raw_call` without `max_outsize` and with `revert_on_failure=True` for some reason returns the boolean value of memory[0] :^)
 
         Which is why we specify `max_outsize=32`, even though don't actually use it.
 
-        To test that `success` returns actual value instead of returning bool of storage[0],
+        To test that `success` returns actual value instead of returning bool of memory[0],
         we need to pause the contract before the sealing,
-        so that the condition `success and is_paused()` is false (i.e `False and True`), see GateSeal.vy, line 174.
+        so that the condition `success and is_paused()` is false (i.e `False and True`), see GateSeal.vy::seal()
 
         For that, we use `__force_pause_for` on SealableMock to ignore any checks and forcefully pause the contract.
         After calling this function, the SealableMock is paused but the call to `pauseFor` will still revert,


### PR DESCRIPTION
capturing `response` to keep the compiler from what acting out,
For details, see https://docs.vyperlang.org/en/stable/built-in-functions.html#raw_call