### PR TITLE
docs: add ape plugins installation step to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,12 @@ poetry install
 yarn
 ```
 
-4. (optional) set `MAINNET_RPC_ENDPOINT` environment variable for mainnet forking
+4. Install ape plugins
+```shell
+ape plugins install .
+```
+
+5. (optional) set `MAINNET_RPC_ENDPOINT` environment variable for mainnet forking
 ```shell
 export MAINNET_RPC_ENDPOINT=<your-mainnet-rpc-endpoint>
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ yarn
 ape plugins install .
 ```
 
-5. (optional) set `MAINNET_RPC_ENDPOINT` environment variable for mainnet forking
+5. (optional) set `MAINNET_RPC_ENDPOINT` environment variable for mainnet forking and deploying
 ```shell
 export MAINNET_RPC_ENDPOINT=<your-mainnet-rpc-endpoint>
 ```


### PR DESCRIPTION
Add missing step for installing ape plugins to Setup section in README.