### PR TITLE
chore: add dependabot config with grouped monthly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
This pull request adds a new configuration file for Dependabot to automate dependency updates for both npm and pip packages. The configuration schedules daily checks and groups all dependencies for each ecosystem, with a limit on the number of open pull requests.

Dependency management automation:

* Added `.github/dependabot.yml` to enable Dependabot for both npm and pip, scheduling daily updates and grouping all dependencies for each ecosystem, with a maximum of three open pull requests per ecosystem.