### PR TITLE
ci: ignore hardhat major and vyper updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,8 @@ updates:
     groups:
       python:
         patterns: ["*"]
+    ignore:
+      - dependency-name: "vyper"
     labels: ["dependencies", "python"]
     commit-message:
       prefix: "build"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     groups:
       javascript:
         patterns: ["*"]
+    ignore:
+      - dependency-name: "hardhat"
+        update-types: ["version-update:semver-major"]
     labels: ["dependencies", "javascript"]
     commit-message:
       prefix: "build"


### PR DESCRIPTION
Two dependabot exclusions:

- **hardhat**: v3 is a breaking rewrite, incompatible with `ape-hardhat ^0.6.4` — the only reason hardhat is a dependency here. Keeps 2.x minor/patch updates flowing. Complements the ignore command on #59.
- **vyper**: pinned to 0.3.7, matching the compiler the deployed GateSeal bytecode was built with (#60 even proposed an rc). Compiler migration should be a deliberate change, not a dependency bump.