### PR TITLE
docs: add archive notice pointing to circuit-breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GateSeal ⛩️
 
+> [!IMPORTANT]
+> **This repository is archived and no longer maintained.** Development has moved to its successor, [circuit-breaker](https://github.com/lidofinance/circuit-breaker).
+
 A one-time panic button for pausable contracts.
 
 ![](/assets/monty-python.png)


### PR DESCRIPTION
Adds a notice at the top of the README that the repository is archived and development continues in [circuit-breaker](https://github.com/lidofinance/circuit-breaker). To be merged right before archiving the repository.